### PR TITLE
Make provisions to set build env script settable

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -87,6 +87,11 @@
           "type": "string",
           "default": "",
           "description": "This setting is used to forward the machine name to bitbake."
+        },
+        "bitbake.oeEnvSetupScript": {
+          "type": "string",
+          "default": "oe-init-build-env",
+          "description": "This script is sourced for Build Environment Setup Script"
         }
       }
     },

--- a/server/src/BitBakeProjectScanner.ts
+++ b/server/src/BitBakeProjectScanner.ts
@@ -90,6 +90,10 @@ export class BitBakeProjectScanner {
         this._settingsScriptInterpreter = scriptInterpreter;
     }
 
+    set oeEnvScript(oeEnvScript: string) {
+        this._oeEnvScript = oeEnvScript;
+    }
+
     set workingPath(workingPath: string) {
         this._settingsWorkingFolder = workingPath;
     }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -86,6 +86,7 @@ interface BitbakeSettings {
 	pathToBashScriptInterpreter: string;
 	machine: string;
 	generateWorkingFolder: boolean;
+	oeEnvSetupScript: string;
 }
 
 function setSymbolScanner( newSymbolScanner: SymbolScanner ) {
@@ -103,6 +104,7 @@ connection.onDidChangeConfiguration((change) => {
 	bitBakeProjectScanner.generateWorkingPath = settings.bitbake.generateWorkingFolder;
 	bitBakeProjectScanner.scriptInterpreter = settings.bitbake.pathToBashScriptInterpreter;
 	bitBakeProjectScanner.machineName = settings.bitbake.machine;
+	bitBakeProjectScanner.oeEnvScript = settings.bitbake.oeEnvSetupScript;
 });
 
 connection.onDidChangeWatchedFiles((change) => {


### PR DESCRIPTION
oe-init-build-env is the default, but some yocto based distributions may have different wrapper scripts to setup the environment. Therefore make it configurable.